### PR TITLE
Fix type errors

### DIFF
--- a/mantis/simulation/routers/test_data.py
+++ b/mantis/simulation/routers/test_data.py
@@ -1,7 +1,8 @@
 # for alignment on input and output of algorithm
 from pathlib import Path
+from loguru import logger
 
-from mantis.simulation.routers.data import (
+from simulation.routers.data import (
     new_data,
     new_pair,
     new_transfer,
@@ -51,6 +52,8 @@ def test_token_price_in_usd_via_oracle():
         90,
     )
     data = new_data([pica_usd], [], {1: None, 2: None})
+    if data.asset_pairs_xyk is None:
+        raise ValueError("asset_pairs_xyk can't be None")
     assert data.asset_pairs_xyk[0].a_usd == 50
     assert data.asset_pairs_xyk[0].b_usd == 50
     assert data.asset_pairs_xyk[0].value_of_a_in_usd == data.token_price_in_usd(1)


### PR DESCRIPTION
/home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:132:18 - error: Type variable "TId" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:133:19 - error: Type variable "TId" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:252:16 - error: Operator "*" not supported for "None" (reportOptionalOperand)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:256:16 - error: Operator "*" not supported for "None" (reportOptionalOperand)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:260:16 - error: Operator "**" not supported for types "TAmount@AssetPairsXyk" and "int"
    Operator "**" not supported for types "str*" and "int" (reportOperatorIssue)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:264:16 - error: Operator "**" not supported for types "TAmount@AssetPairsXyk" and "int"
    Operator "**" not supported for types "str*" and "int" (reportOperatorIssue)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:271:25 - error: Function with declared return type "float" must return value on all code paths
    "None" is incompatible with "float" (reportReturnType)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:275:9 - warning: Expression value is unused (reportUnusedExpression)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:278:26 - error: Function with declared return type "float" must return value on all code paths
    "None" is incompatible with "float" (reportReturnType)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:282:9 - warning: Expression value is unused (reportUnusedExpression)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:330:18 - error: Type variable "TId" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:332:22 - error: Type variable "TAmount" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:342:22 - error: Type variable "TAmount" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:347:18 - error: Type variable "TId" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:349:14 - error: Type variable "TId" has no meaning in this context (reportGeneralTypeIssues)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:352:6 - error: Argument of type "(self: Self@Exchange) -> Exchange" cannot be assigned to parameter of type "_AnyModelAfterValidator[_ModelType@model_validator]"
    Type "(self: Self@Exchange) -> Exchange" cannot be assigned to type "_AnyModelAfterValidator[_ModelType@model_validator]"
      Type "(self: Self@Exchange) -> Exchange" cannot be assigned to type "(_ModelType@model_validator, ValidationInfo) -> _ModelType@model_validator"
        Function accepts too many positional parameters; expected 1 but received 2
          Parameter 1: type "_ModelType@model_validator" cannot be assigned to type "Self@Exchange"
            Type "Exchange" cannot be assigned to type "Self@Exchange"
      Type "(self: Self@Exchange) -> Exchange" cannot be assigned to type "(_ModelType@model_validator) -> _ModelType@model_validator"
        Parameter 1: type "_ModelType@model_validator" cannot be assigned to type "Self@Exchange"
          Type "Exchange" cannot be assigned to type "Self@Exchange" (reportArgumentType)
  /home/legion/Documents/ComposableFi/cvm/mantis/simulation/routers/data.py:372:12 - error: Union requires two or more type arguments (reportInvalidTypeArguments)